### PR TITLE
[ENH] Generate meaningful chat title using OpenAI instruct model

### DIFF
--- a/apps/web/app/services/langchain/messages.ts
+++ b/apps/web/app/services/langchain/messages.ts
@@ -93,7 +93,11 @@ export const buildTitleFromHistory = async ({
     return firstMessage.message;
   };
 
-  const model = new OpenAI({ openAIApiKey, temperature: 0 });
+  const model = new OpenAI({
+    openAIApiKey,
+    temperature: 0,
+    modelName: "gpt-3.5-turbo-instruct",
+  });
   const prompt = PromptTemplate.fromTemplate(
     "There's the first message from the user to the chat assistant, please provide a short and meaningful title for it {message}. Do not include prefixes like 'Title: '.",
   );


### PR DESCRIPTION
* Switch from deprecated OpenAI model to gpt-3.5-turbo-instruct for generating chat titles
* Use OpenAI API with temperature set to 0 for more deterministic outputs
* Refactor buildTitleFromHistory function to use the new model and parameters

This change enhances the chat title generation by leveraging the more advanced and instruction-tuned gpt-3.5-turbo-instruct model from OpenAI. The new model should provide more accurate and relevant titles based on the initial user message.